### PR TITLE
Add indetion to avoid TypeError exception thrown in line 322

### DIFF
--- a/font-awesome-to-png.py
+++ b/font-awesome-to-png.py
@@ -319,16 +319,16 @@ def export_icon(icon, size, filename, font, color):
     if bbox:
         image = image.crop(bbox)
 
-    borderw = int((size - (bbox[2] - bbox[0])) / 2)
-    borderh = int((size - (bbox[3] - bbox[1])) / 2)
+        borderw = int((size - (bbox[2] - bbox[0])) / 2)
+        borderh = int((size - (bbox[3] - bbox[1])) / 2)
 
-    # Create background image
-    bg = Image.new("RGBA", (size, size), (0,0,0,0))
+        # Create background image
+        bg = Image.new("RGBA", (size, size), (0,0,0,0))
 
-    bg.paste(image, (borderw,borderh))
+        bg.paste(image, (borderw,borderh))
 
-    # Save file
-    bg.save(filename)
+        # Save file
+        bg.save(filename)
 
 parser = argparse.ArgumentParser(
         description="Exports Font Awesome icons as PNG images.")


### PR DESCRIPTION
When I try to generate all the fonts into PNG using command:

``` shell
./font-awesome-to-png.py ALL
```

An error occurred like this:

``` python
Traceback (most recent call last):
  File "./font-awesome-to-png.py", line 394, in <module>
    export_icon(icon, size, filename, font, color)
  File "./font-awesome-to-png.py", line 322, in export_icon
    borderw = int((size - (bbox[2] - bbox[0])) / 2)
```

I just simply add some indention to that line to avoid this exception
