### PR TITLE
--size-adjust for icons that appear to be cropped

### DIFF
--- a/font-awesome-to-png.py
+++ b/font-awesome-to-png.py
@@ -411,13 +411,13 @@ class ListAction(argparse.Action):
             print(icon)
         exit(0)
 
-def export_icon(icon, size, filename, font, color):
+def export_icon(icon, size, size_adjust, filename, font, color):
     image = Image.new("RGBA", (size, size), color=(0,0,0,0))
 
     draw = ImageDraw.Draw(image)
 
     # Initialize font
-    font = ImageFont.truetype(font, size)
+    font = ImageFont.truetype(font, size - size_adjust)
 
     # Determine the dimensions of the icon
     width,height = draw.textsize(icons[icon], font=font)
@@ -458,12 +458,15 @@ parser.add_argument("--list", nargs=0, action=ListAction,
         help="List available icon names and exit")
 parser.add_argument("--size", type=int, default=16,
         help="Icon size in pixels (default: 16)")
+parser.add_argument("--size-adjust", type=int, default=0,
+        help="Decrease icon size by this many pixels (default: 0)")
 
 args = parser.parse_args()
 icon = args.icon
 size = args.size
 font = args.font
 color = args.color
+size_adjust = args.size_adjust
 
 if args.font:
     if not path.isfile(args.font) or not access(args.font, R_OK):
@@ -503,5 +506,5 @@ for icon in selected_icons:
     print("Exporting icon \"%s\" as %s (%ix%i pixels)" %
             (icon, filename, size, size))
 
-    export_icon(icon, size, filename, font, color)
+    export_icon(icon, size, size_adjust, filename, font, color)
 


### PR DESCRIPTION
Hi there, thanks for this script, that's exactly what I needed.

On my system though, some icons appear to be cropped as if their rendered size exceeded the image's. I've added a command line option that subtracts some pixels from the font size, to compensate for that.

The two PNGs below have been respectively created with:

```
./font-awesome-to-png.py --size 40 warning-sign
./font-awesome-to-png.py --size 40 --size-adjust 4 warning-sign
```

![](http://i.imgur.com/hhPltGZ.png)

__
Giuliano
