### PR TITLE
Fixing the icon character codes read in the Font-Awesome css file

### DIFF
--- a/font-awesome-to-png.py
+++ b/font-awesome-to-png.py
@@ -429,7 +429,9 @@ class LoadCSSAction(argparse.Action):
                 name = match.groups()[0]
                 for declaration in rule.declarations:
                     if declaration.name == u("content"):
-                        new_icons[name] = declaration.value.as_css()
+                        val = declaration.value.as_css()
+                        val = re.sub(r'"\\([a-zA-Z_0-9]+)"', r'\u\1', val)
+                        new_icons[name] = u(val)
         return new_icons
 
 

--- a/font-awesome-to-png.py
+++ b/font-awesome-to-png.py
@@ -361,6 +361,7 @@ icons = {
 }
 
 
+
 class ListAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         for icon in sorted(icons.keys()):


### PR DESCRIPTION
I tried to export the Font-Awesome 4.0.3 icons, using both ttf and css files with this script and Python 2.7.3, but the created png files were unusable.

Character codes in the css file are different than the ones defined in the script (e.g., "\f042" vs. "\uf042").

This quick fix is definitely not the most elegant solution but it works with Python 2.7 (I haven't tested it with Python 3).
